### PR TITLE
Validate shape of non existence proofs in go

### DIFF
--- a/go/ics23.go
+++ b/go/ics23.go
@@ -43,7 +43,7 @@ func VerifyMembership(spec *ProofSpec, root CommitmentRoot, proof *CommitmentPro
 // both left and right sub-proofs are valid existence proofs (see above) or nil
 // left and right proofs are neighbors (or left/right most if one is nil)
 // provided key is between the keys of the two proofs
-func VerifyNonMembership(spec *ProofSpec, root CommitmentRoot, proof CommitmentProof, key []byte) bool {
+func VerifyNonMembership(spec *ProofSpec, root CommitmentRoot, proof *CommitmentProof, key []byte) bool {
 	// TODO: handle batch
 	np, ok := proof.Proof.(*CommitmentProof_Nonexist)
 	if !ok {

--- a/go/proof.go
+++ b/go/proof.go
@@ -2,7 +2,6 @@ package proofs
 
 import (
 	"bytes"
-	"fmt"
 	"github.com/pkg/errors"
 )
 
@@ -246,8 +245,6 @@ func getPadding(spec *InnerSpec, branch int32) (minPrefix, maxPrefix, suffix int
 
 	// count how many children are in the suffix
 	suffix = (len(spec.ChildOrder) - 1 - idx) * int(spec.ChildSize)
-
-	fmt.Printf("prefix: %d -> %d, suffix: %d\n", minPrefix, maxPrefix, suffix)
 	return
 }
 

--- a/proofs.proto
+++ b/proofs.proto
@@ -180,7 +180,9 @@ This enables:
   isLeftNeighbor(spec: InnerSpec, left: InnerOp, right: InnerOp)
 */
 message InnerSpec {
-    // TODO
+    // Child order is the ordering of the children node, must count from 0
+    // iavl tree is [0, 1] (left then right)
+    // merk is [0, 2, 1] (left, right, here)
     repeated int32 child_order = 1;
     int32 child_size = 2;
     int32 min_prefix_length = 3;


### PR DESCRIPTION
A start on #4

Full logic in go verification to check for iavl and tendermint generated proofs.
Still some work to do to generalize to merk proof (different shape: (left, right, here)).

Also need to port to other languages
